### PR TITLE
Add markdown lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Markdown Lint
+on: pull_request
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repo
+      uses: actions/checkout@v2
+    - name: Get file changes
+      id: get_file_changes
+      uses: trilom/file-changes-action@v1.2.3
+      with:
+        output: ' '
+    - name: Echo changed files
+      run: |
+        echo Changed files: ${{ steps.get_file_changes.outputs.files }}
+    - name: Get only md files
+      id: get_md_changes
+      run: |
+        echo -e "::set-output name=files::\c";echo "${{ steps.get_file_changes.outputs.files }}" | for i in $(cat) ; do if [[ $i == *.md ]]; then echo -e "$i \c"; fi  ;done
+    - name: markdownlint-cli
+      if: ${{ steps.get_md_changes.outputs.files}}
+      uses: nosborn/github-action-markdown-cli@v1.1.1
+      with:
+        files: ${{ steps.get_md_changes.outputs.files}}
+        config_file: ".markdownlint"

--- a/.markdownlint
+++ b/.markdownlint
@@ -1,0 +1,5 @@
+{
+  "default": false,
+  "MD041": true,
+  "MD013": { "line_length": 120 }
+}


### PR DESCRIPTION
I noticed that there is no linter enabled for the Markdown files. Thus, if you forget to add a proper heading at the top of a `md` file you'd be "ruining" the `README` generation process.

I added a workflow that triggers on PRs with very relaxed rules:

- Enforce the first line to be a heading ([more info](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md041---first-line-in-file-should-be-a-top-level-heading))
- Restrict the line length to 120 chars ([more info](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013---line-length))

For a complete list of rules you can take a look [over here](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md).

Rules can be easily modified by changing the `.markdownlint` file.

Led me know if you find this useful or if you think the rules should be different.

Thanks!