### PR TITLE
Update compile-sqlite3-rsync.md

### DIFF
--- a/sqlite/compile-sqlite3-rsync.md
+++ b/sqlite/compile-sqlite3-rsync.md
@@ -8,7 +8,7 @@ Today I heard about the [sqlite3-rsync](https://sqlite.org/draft/rsync.html) com
 git clone https://github.com/sqlite/sqlite.git
 cd sqlite
 ./configure
-make sqlite3-rsync
+make sqlite3_rsync
 ```
 So it looks like the `sqlite-rsync` command is no longer limited to a branch.
 


### PR DESCRIPTION
Fix invalid make target. I tried to compile with your instructions and couldn't find the target. I dug around in the makefile and found an underscore instead of a hyphen. Unsure if things changed or simply an oversight from the HN OP